### PR TITLE
Add rudimentary tab component.

### DIFF
--- a/components/ButtonRow.jsx
+++ b/components/ButtonRow.jsx
@@ -76,16 +76,19 @@ function ButtonRow({
     }
 
     return (
-      rows.map((row, idx) => {
-          return (
-            <div 
+      <>
+        {rows.map((row, idx) => {
+            return (
+              <div 
               key={`${type}_${row}_${idx}`} 
               className="w-screen max-w-full flex justify-center items-center pb-1 gap-1"
-            >
+              >
               {row}
-            </div>
-          )
-        })
+              </div>
+            )
+          })
+        }
+      </>
     )
   }
 

--- a/components/Tab.jsx
+++ b/components/Tab.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types'
+
+function Tab({title, active, children}) {
+  console.log(children[0].props)
+
+  return (
+    <>
+      {children}
+    </>
+  )
+}
+
+Tab.propTypes = {
+  title: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired
+}
+
+export default Tab

--- a/components/TabContainer.jsx
+++ b/components/TabContainer.jsx
@@ -1,0 +1,47 @@
+import { useState } from "react"
+import buttonStyles from '../styles/components/ToggleButton.module.css' 
+
+function TabContainer({children, onTabChange}) {
+  const [tabs] = useState(children.map(child => child.props.title))
+  const [activeTab, setActiveTab] = useState(
+    children.find(child => child.props.active) ? 
+    children.find(child => child.props.active).props.title : null
+  )
+
+  function onClick(e) {
+    setActiveTab(e.target.innerText)
+  }
+
+  return (
+    <div className="">
+      <div className="flex gap-1 pb-1 mb-2">
+      {tabs.map(tab => (
+          <button 
+            onClick={onClick} 
+            className={
+              buttonStyles.button 
+              + " h-4 " 
+              + (tab === activeTab ? buttonStyles.buttonTabSelected : "")
+            } 
+            key={tab}
+          >
+            {tab}
+          </button>
+        )
+      )}
+      </div>
+      <div>
+      {children.map((child, idx) => {
+        if (activeTab && child.props.title === activeTab) {
+          return <div key={`tabChild${idx}`}>{child}</div>
+        } else {
+          return <div key={`tabChild${idx}`} className="hidden">{child}</div>
+        }
+
+      })}
+      </div>
+    </div>
+  )
+}
+
+export default TabContainer

--- a/components/sections/ArmorSection.jsx
+++ b/components/sections/ArmorSection.jsx
@@ -41,8 +41,6 @@ export default function ArmorSection({ filter, data, filterId, armourBaseTypes }
     }) 
   }
 
-  console.log(details)
-
   return (
     <Section name="Armour Bases">
       <ButtonRow 

--- a/components/sections/WeaponSection.jsx
+++ b/components/sections/WeaponSection.jsx
@@ -4,6 +4,8 @@ import ButtonRow from "../ButtonRow"
 import InputField from "../InputField"
 import ExceptionContainer from "../ExceptionContainer"
 import TierColumn from "../TierColumn"
+import TabContainer from "../TabContainer"
+import Tab from "../Tab"
 import {useEffect, useReducer, useState} from "react"
 import { buttonChoices } from "../ToggleButton"
 import { cycleThroughChoicesByValue } from "../../utils/buttonUtils"
@@ -116,104 +118,103 @@ function WeaponSection({
 
   return (
     <Section name="Weapons">
-      <div>
-        <h3>{baseTypes.melee.heading}</h3>
-        <ButtonRow 
-          details={meleeDetails.melee}
-          type="melee"
-          selection={selectionName}
-          filter={filter}
-          filterId={filterId}
-          maxButtons={3}
-          fields={["melee", "bases"]}
-        />
-        <div className="w-screen max-w-full flex items-end flex-row mt-2 mb-2 p-2 gap-1 box-shadow">
-          <div className="ml-auto">
-            <ToggleButton 
-              name={"Physical"}
-              title={"Include physical damage bases"}
-              currentChoice={meleeOptions.physical}
-              choices={dmgTypeChoices}
-              type={"bases"}
-              onClick={handleMPDClick}
-              styleOverrides="p-0 h-1"
-            />
+      <TabContainer>
+        <Tab title={baseTypes.melee.heading} active={true} key="meleeTab">
+          <ButtonRow 
+            details={meleeDetails.melee}
+            type="melee"
+            selection={selectionName}
+            filter={filter}
+            filterId={filterId}
+            maxButtons={3}
+            fields={["melee", "bases"]}
+          />
+          <div className="w-screen max-w-full flex items-end flex-row mt-2 mb-2 p-2 gap-1 ">
+            <div className="ml-auto">
+              <ToggleButton 
+                name={"Physical"}
+                title={"Include physical damage bases"}
+                currentChoice={meleeOptions.physical}
+                choices={dmgTypeChoices}
+                type={"bases"}
+                onClick={handleMPDClick}
+                styleOverrides="p-0 h-1"
+              />
+            </div>
+            <div className="mr-auto">
+              <ToggleButton 
+                name={"Elemental"}
+                title={"Include elemental damage bases"}
+                currentChoice={meleeOptions.elemental}
+                choices={dmgTypeChoices}
+                type={"bases"}
+                onClick={handleMEDClick}
+                styleOverrides="p-0 h-1"
+              />
+            </div>
           </div>
-          <div className="mr-auto">
-            <ToggleButton 
-              name={"Elemental"}
-              title={"Include elemental damage bases"}
-              currentChoice={meleeOptions.elemental}
-              choices={dmgTypeChoices}
-              type={"bases"}
-              onClick={handleMEDClick}
-              styleOverrides="p-0 h-1"
-            />
+        </Tab>
+        <Tab title={baseTypes.ranged.heading} active={false} key="rangedTab">
+          <ButtonRow 
+            details={rangedDetails.ranged}
+            type="ranged"
+            selection={selectionName}
+            filter={filter}
+            filterId={filterId}
+            maxButtons={3}
+            fields={["ranged", "bases"]}
+          />
+          <div className="w-screen max-w-full flex items-end flex-row mt-2 p-2 mb-2 gap-1 ">
+            <div className="ml-auto">
+              <ToggleButton 
+                name={"Physical"}
+                title={"Include physical damage bases"}
+                currentChoice={rangedOptions.physical}
+                choices={dmgTypeChoices}
+                type={"bases"}
+                onClick={handleRPDClick}
+                styleOverrides="p-0 h-1"
+              />
+            </div>
+            <div className="mr-auto">
+              <ToggleButton 
+                name={"Elemental"}
+                title={"Include elemental damage bases"}
+                currentChoice={rangedOptions.elemental}
+                choices={dmgTypeChoices}
+                type={"bases"}
+                onClick={handleREDClick}
+                styleOverrides="p-0 h-1"
+              />
+            </div>
           </div>
-        </div>
-      </div>
-      <div>
-        <h3>{baseTypes.ranged.heading}</h3>
-        <ButtonRow 
-          details={rangedDetails.ranged}
-          type="ranged"
-          selection={selectionName}
-          filter={filter}
-          filterId={filterId}
-          maxButtons={3}
-          fields={["ranged", "bases"]}
-        />
-        <div className="w-screen max-w-full flex items-end flex-row mt-2 p-2 mb-2 gap-1 box-shadow">
-          <div className="ml-auto">
-            <ToggleButton 
-              name={"Physical"}
-              title={"Include physical damage bases"}
-              currentChoice={rangedOptions.physical}
-              choices={dmgTypeChoices}
-              type={"bases"}
-              onClick={handleRPDClick}
-              styleOverrides="p-0 h-1"
-            />
+        </Tab>
+        <Tab title={baseTypes.caster.heading} active={false} key="casterTab">
+          <ButtonRow 
+            details={casterDetails.caster}
+            type="caster"
+            selection={selectionName}
+            filter={filter}
+            filterId={filterId}
+            fields={["caster", "bases"]}
+          />
+          <div className="w-screen max-w-full flex justify-center items-end flex-row p-2 gap-1 ">
+            <div className="w-1/2">
+              <TierColumn 
+                name={"tiers"}
+                heading={"Caster weapon tiers"}
+                fields={["caster", "options", "tiers"]}
+                tiers={tiers}
+                selection={selectionName}
+                filter={filter}
+                filterId={filterId}
+                direction="row"
+                buttonSize="small"
+              />
+            </div>
           </div>
-          <div className="mr-auto">
-            <ToggleButton 
-              name={"Elemental"}
-              title={"Include elemental damage bases"}
-              currentChoice={rangedOptions.elemental}
-              choices={dmgTypeChoices}
-              type={"bases"}
-              onClick={handleREDClick}
-              styleOverrides="p-0 h-1"
-            />
-          </div>
-        </div>
-      </div>
-      <div>
-        <h3>{baseTypes.caster.heading}</h3>
-        <ButtonRow 
-          details={casterDetails.caster}
-          type="caster"
-          selection={selectionName}
-          filter={filter}
-          filterId={filterId}
-          fields={["caster", "bases"]}
-        />
-        <div className="w-screen max-w-full flex justify-center items-end flex-row p-2 gap-1 box-shadow">
-          <div className="w-1/2">
-            <TierColumn 
-              name={"tiers"}
-              heading={"Caster weapon tiers"}
-              fields={["caster", "options", "tiers"]}
-              tiers={tiers}
-              selection={selectionName}
-              filter={filter}
-              filterId={filterId}
-              direction="row"
-              buttonSize="small"
-            />
-          </div>
-        </div>
-      </div>
+        </Tab>
+      </TabContainer>
       <div className="w-screen max-w-full flex items-end flex-row mt-4 mb-2 p-2 gap-1 box-shadow">
         <InputField 
           defaultValue={defaultIlvl}

--- a/data/sample_filter.js
+++ b/data/sample_filter.js
@@ -139,6 +139,13 @@ var defaultWeaponSelection = {
     }
 }
 
+db.filter.updateOne(
+    {name: "F1"},
+    {$set: defaultWeaponSelection },
+    {$set: defaultArmourSelection },
+)
+
+
 db.filter.updateMany(
     {},
     {$set: defaultWeaponSelection },

--- a/styles/components/ToggleButton.module.css
+++ b/styles/components/ToggleButton.module.css
@@ -43,3 +43,11 @@
   background: var(--unselected-item-bg);
   background: linear-gradient(180deg, var(--unselected-item-bg) 97%, var(--green) 97% 100%);
 }
+
+.buttonTabSelected { 
+  color: var(--orange);
+  fill: var(--orange);
+  border: 1px solid var(--unselected-item-bg);
+  background: var(--unselected-item-bg);
+  background: linear-gradient(180deg, var(--unselected-item-bg) 97%, var(--orange) 97% 100%);
+}


### PR DESCRIPTION
To use less screen space and separate different types of weapons or other item types. It should be extended to track wether a tab actually contains any selected items or not, and describe that state through the heading-buttons.